### PR TITLE
Implementing std::error::Error trait for error types

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -4,10 +4,34 @@ pub struct ServerOtherBodyError {
     pub status_message: String,
 }
 
+impl std::fmt::Display for ServerOtherBodyError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "Server Error with status code {}: {}",
+            self.status_code, self.status_message
+        )
+    }
+}
+
+impl std::error::Error for ServerOtherBodyError {}
+
 #[derive(Debug, Deserialize, Serialize)]
 pub struct ServerValidationBodyError {
     pub errors: Vec<String>,
 }
+
+impl std::fmt::Display for ServerValidationBodyError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        for (idx, error) in self.errors.iter().enumerate() {
+            let formatted_idx = format!("{: >2}. ", idx + 1);
+            write!(f, "{}{}\n", formatted_idx, error)?;
+        }
+        Ok(())
+    }
+}
+
+impl std::error::Error for ServerValidationBodyError {}
 
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(untagged)]
@@ -15,6 +39,21 @@ pub enum ServerBodyError {
     Other(ServerOtherBodyError),
     Validation(ServerValidationBodyError),
 }
+
+impl std::fmt::Display for ServerBodyError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Other(other) => {
+                write!(f, "{other}")
+            }
+            Self::Validation(validation) => {
+                write!(f, "{validation}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for ServerBodyError {}
 
 impl From<ServerOtherBodyError> for ServerBodyError {
     fn from(inner: ServerOtherBodyError) -> Self {
@@ -50,12 +89,35 @@ pub struct ServerError {
     pub body: ServerBodyError,
 }
 
+impl std::fmt::Display for ServerError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Server Error with code {}: {}", self.code, self.body)
+    }
+}
+
+impl std::error::Error for ServerError {}
+
 #[cfg(feature = "commands")]
 #[derive(Debug)]
 pub enum Error {
     Reqwest(reqwest::Error),
     Server(ServerError),
 }
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Error::Reqwest(reqwest) => {
+                write!(f, "{reqwest}")
+            }
+            Error::Server(server) => {
+                write!(f, "{server}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for Error {}
 
 #[cfg(feature = "commands")]
 impl Error {


### PR DESCRIPTION
# #61 Implementing std::error::Error trait for error types

This pull request adds implementations of the std::error::Error trait for several error types within the project. The goal of these implementations is to make the error types compatible with the standard library's error handling mechanisms, facilitating interoperability with other Rust libraries and providing a consistent error handling experience for developers using this project.

## Changes:
- Implemented std::error::Error trait for `ServerError`, `ServerBodyError`, `ServerOtherBodyError`, `ServerValidationBodyError`, and `Error` types.
- Provided meaningful `Display` implementations for error types to improve error message clarity.

If you don't like anything you can write me and I can work on themn.