### PR TITLE
Add `Sync` bound for request & response errors and `Clone` bound for Executor

### DIFF
--- a/src/client/prelude.rs
+++ b/src/client/prelude.rs
@@ -23,7 +23,7 @@
 use std::borrow::Cow;
 
 #[async_trait::async_trait]
-pub trait Executor: Default + Send + Sync {
+pub trait Executor: Default + Send + Sync + Clone {
     async fn execute<T: serde::de::DeserializeOwned>(
         &self,
         url: &str,

--- a/src/client/reqwest.rs
+++ b/src/client/reqwest.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct ReqwestExecutor {
     inner: reqwest::Client,
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -79,12 +79,12 @@ pub enum Error {
     #[error("couldn't execute request")]
     Request {
         #[source]
-        source: Box<dyn std::error::Error + Send>,
+        source: Box<dyn std::error::Error + Send + Sync>,
     },
     #[error("couldn't read response")]
     Response {
         #[source]
-        source: Box<dyn std::error::Error + Send>,
+        source: Box<dyn std::error::Error + Send + Sync>,
     },
     #[error(transparent)]
     Validation(ServerValidationBodyError),


### PR DESCRIPTION
See e.g. the following:
```rust
use anyhow::anyhow;
use tmdb_api::{client::reqwest::ReqwestExecutor, prelude::Command};

async fn foo() -> anyhow::Result<()> {
    _ = tmdb_api::tvshow::search::TVShowSearch::new("Gravity Falls".to_owned())
        .execute(&tmdb_api::Client::<ReqwestExecutor>::new(
            "api_key".to_owned(),
        ))
        .await
        .map_err(|e| anyhow!(e).context("Could not call TMDB API"));

    Ok(())
}
```

The `anyhow!(e)` call will fail because `e: tmdb_api::error::Error ` "doesn't satisfy `tmdb_api::error::Error: Into<anyhow::Error>`, `tmdb_api::error::Error: Sync` or `tmdb_api::error::Error: anyhow::kind::TraitKind`". Adding the `Sync` bound seems like the simplest fix of the three.

`Clone` is required by e.g. Axum for Extensions (see https://docs.rs/axum/latest/axum/struct.Extension.html).