### PR TITLE
feat: ts-rs support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -131,8 +140,12 @@ version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
 dependencies = [
+ "iana-time-zone",
+ "js-sys",
  "num-traits",
  "serde",
+ "wasm-bindgen",
+ "windows-link",
 ]
 
 [[package]]
@@ -143,6 +156,12 @@ checksum = "fde0e0ec90c9dfb3b4b1a0891a7dcd0e2bffde2f7efed5fe7c9bb00e5bfb915e"
 dependencies = [
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "displaydoc"
@@ -380,6 +399,30 @@ dependencies = [
  "tokio",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33e57f83510bb73707521ebaffa789ec8caf86f9657cad665b092b581d40e9fb"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -1168,6 +1211,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1245,6 +1297,7 @@ dependencies = [
  "serde_repr",
  "thiserror 2.0.16",
  "tokio",
+ "ts-rs",
 ]
 
 [[package]]
@@ -1370,6 +1423,29 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "ts-rs"
+version = "11.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ef1b7a6d914a34127ed8e1fa927eb7088903787bcded4fa3eef8f85ee1568be"
+dependencies = [
+ "chrono",
+ "thiserror 2.0.16",
+ "ts-rs-macros",
+]
+
+[[package]]
+name = "ts-rs-macros"
+version = "11.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9d4ed7b4c18cc150a6a0a1e9ea1ecfa688791220781af6e119f9599a8502a0a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "termcolor",
+]
 
 [[package]]
 name = "unicode-ident"
@@ -1537,6 +1613,74 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2853738d1cc4f2da3a225c18ec6c3721abb31961096e9dbf5ab35fa88b19cfdb"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.62.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6844ee5416b285084d3d3fffd743b925a6c9385455f64f6d4fa3031c4c2749a9"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edb307e42a74fb6de9bf3a02d9712678b22399c87e6fa869d6dfcd8c1b7754e0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0abd1ddbc6964ac14db11c7213d6532ef34bd9aa042c2e5935f59d7908b46a5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
+
+[[package]]
+name = "windows-result"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7084dcc306f89883455a206237404d3eaf961e5bd7e0f312f7c91f57eb44167f"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7218c655a553b0bed4426cf54b20d7ba363ef543b52d515b3e48d7fd55318dda"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ readme = "readme.md"
 reqwest-middleware = ["dep:reqwest-middleware"]
 # only used for testing
 integration = []
+ts-rs = ["dep:ts-rs"]
 
 [dependencies]
 chrono = { version = "0.4", default-features = false, features = [
@@ -28,6 +29,7 @@ reqwest-middleware = { version = "0.4", optional = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_repr = { version = "0.1" }
 thiserror = { version = "2.0" }
+ts-rs = { version = "11.0.1", optional = true, features = ["chrono-impl", "no-serde-warnings"] }
 
 [dev-dependencies]
 mockito = { version = "1.4" }

--- a/src/certification.rs
+++ b/src/certification.rs
@@ -9,6 +9,7 @@ const TV_PATH: &str = "/certification/tv/list";
 const MOVIE_PATH: &str = "/certification/movie/list";
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
 pub struct Certification {
     pub certification: String,
     pub meaning: String,

--- a/src/changes/list.rs
+++ b/src/changes/list.rs
@@ -7,6 +7,7 @@ const MOVIE_PATH: &str = "/movie/changes";
 const PERSON_PATH: &str = "/person/changes";
 
 #[derive(Clone, Debug, Default, Serialize)]
+#[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
 pub struct Params {
     /// Filter the results with a start date.
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/changes/mod.rs
+++ b/src/changes/mod.rs
@@ -1,6 +1,7 @@
 pub mod list;
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
 pub struct Change {
     pub id: Option<u64>,
     pub adult: Option<bool>,

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -77,6 +77,7 @@ impl<E: prelude::Executor> ClientBuilder<E> {
 }
 
 #[derive(Serialize)]
+#[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
 struct WithApiKey<'a, V> {
     api_key: &'a str,
     #[serde(flatten)]

--- a/src/collection/details.rs
+++ b/src/collection/details.rs
@@ -1,6 +1,7 @@
 use crate::client::Executor;
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
+#[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
 #[serde(rename_all = "lowercase")]
 pub enum MediaType {
     Movie,
@@ -9,6 +10,7 @@ pub enum MediaType {
 }
 
 #[derive(Debug, Deserialize, Serialize)]
+#[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
 pub struct CollectionDetails {
     #[serde(flatten)]
     pub inner: super::CollectionBase,
@@ -16,6 +18,7 @@ pub struct CollectionDetails {
 }
 
 #[derive(Debug, Deserialize, Serialize)]
+#[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
 pub struct Media {
     pub id: u64,
     pub media_type: MediaType,

--- a/src/collection/mod.rs
+++ b/src/collection/mod.rs
@@ -1,6 +1,7 @@
 pub mod details;
 
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
 pub struct CollectionBase {
     pub id: u64,
     pub name: String,

--- a/src/common/country.rs
+++ b/src/common/country.rs
@@ -1,4 +1,5 @@
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
 pub struct Country {
     pub iso_3166_1: String,
     pub name: String,

--- a/src/common/credits.rs
+++ b/src/common/credits.rs
@@ -1,6 +1,7 @@
 use crate::people::PersonShort;
 
 #[derive(Debug, Deserialize, Serialize)]
+#[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
 pub struct CreditCommon {
     pub credit_id: String,
     pub adult: bool,
@@ -10,6 +11,7 @@ pub struct CreditCommon {
 }
 
 #[derive(Debug, Deserialize, Serialize)]
+#[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
 pub struct Cast {
     #[serde(flatten)]
     pub credit: CreditCommon,
@@ -21,6 +23,7 @@ pub struct Cast {
 }
 
 #[derive(Debug, Deserialize, Serialize)]
+#[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
 pub struct Crew {
     #[serde(flatten)]
     pub credit: CreditCommon,

--- a/src/common/image.rs
+++ b/src/common/image.rs
@@ -1,4 +1,5 @@
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
 pub struct Image {
     pub aspect_ratio: f64,
     pub file_path: String,

--- a/src/common/keyword.rs
+++ b/src/common/keyword.rs
@@ -1,4 +1,5 @@
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
 pub struct Keyword {
     pub id: u64,
     pub name: String,

--- a/src/common/language.rs
+++ b/src/common/language.rs
@@ -1,4 +1,5 @@
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
 pub struct Language {
     pub iso_639_1: String,
     pub name: String,

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -10,6 +10,7 @@ pub mod status;
 pub mod video;
 
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
 pub struct PaginatedResult<T> {
     pub page: u64,
     pub total_results: u64,
@@ -18,17 +19,20 @@ pub struct PaginatedResult<T> {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
 pub struct EntityResults<V> {
     pub id: u64,
     pub results: V,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
 pub struct Results<V> {
     pub results: V,
 }
 
 #[derive(Clone, Debug, Default, Serialize)]
+#[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
 pub struct LanguageParams<'a> {
     /// ISO 639-1 value to display translated data for the fields that support
     /// it.
@@ -48,6 +52,7 @@ impl<'a> LanguageParams<'a> {
 }
 
 #[derive(Clone, Debug, Default, serde::Serialize)]
+#[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
 pub struct LanguagePageParams<'a> {
     /// ISO 639-1 value to display translated data for the fields that support
     /// it.

--- a/src/common/release_date.rs
+++ b/src/common/release_date.rs
@@ -1,10 +1,12 @@
 #[derive(Debug, Deserialize, Serialize)]
+#[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
 pub struct LocatedReleaseDates {
     pub iso_3166_1: String,
     pub release_dates: Vec<ReleaseDate>,
 }
 
 #[derive(Serialize_repr, Deserialize_repr, PartialEq, Debug)]
+#[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
 #[repr(u8)]
 pub enum ReleaseDateKind {
     Premiere = 1,
@@ -16,6 +18,7 @@ pub enum ReleaseDateKind {
 }
 
 #[derive(Debug, Deserialize, Serialize)]
+#[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
 pub struct ReleaseDate {
     #[serde(deserialize_with = "crate::util::empty_string::deserialize")]
     pub certification: Option<String>,

--- a/src/common/status.rs
+++ b/src/common/status.rs
@@ -1,4 +1,5 @@
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Deserialize, Serialize)]
+#[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
 pub enum Status {
     Rumored,
     Planned,

--- a/src/common/video.rs
+++ b/src/common/video.rs
@@ -1,4 +1,5 @@
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
 pub struct Video {
     pub id: String,
     pub name: String,

--- a/src/company/alternative_names.rs
+++ b/src/company/alternative_names.rs
@@ -4,6 +4,7 @@ use crate::common::EntityResults;
 pub type Response = EntityResults<Vec<CompanyAlternativeName>>;
 
 #[derive(Debug, Deserialize, Serialize)]
+#[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
 pub struct CompanyAlternativeName {
     pub name: String,
     #[serde(

--- a/src/company/images.rs
+++ b/src/company/images.rs
@@ -1,6 +1,7 @@
 use crate::client::Executor;
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
 pub struct CompanyImage {
     pub aspect_ratio: f64,
     pub file_path: String,

--- a/src/company/mod.rs
+++ b/src/company/mod.rs
@@ -5,6 +5,7 @@ pub mod details;
 pub mod images;
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
 pub struct CompanyShort {
     pub id: u64,
     pub name: String,
@@ -14,6 +15,7 @@ pub struct CompanyShort {
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
 pub struct Company {
     #[serde(flatten)]
     pub inner: CompanyShort,

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,5 @@
 #[derive(Debug, Deserialize, Serialize)]
+#[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
 pub struct ServerOtherBodyError {
     pub status_code: u16,
     pub status_message: String,
@@ -16,6 +17,7 @@ impl std::fmt::Display for ServerOtherBodyError {
 }
 
 #[derive(Debug, Deserialize, Serialize)]
+#[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
 pub struct ServerValidationBodyError {
     pub errors: Vec<String>,
 }
@@ -32,6 +34,7 @@ impl std::fmt::Display for ServerValidationBodyError {
 }
 
 #[derive(Debug, Deserialize, Serialize, thiserror::Error)]
+#[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
 #[serde(untagged)]
 pub enum ServerBodyError {
     #[error(transparent)]

--- a/src/genre.rs
+++ b/src/genre.rs
@@ -7,6 +7,7 @@ const TV_PATH: &str = "/genre/tv/list";
 const MOVIE_PATH: &str = "/genre/movie/list";
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
 pub struct Genre {
     pub id: u64,
     pub name: String,

--- a/src/movie/alternative_titles.rs
+++ b/src/movie/alternative_titles.rs
@@ -3,6 +3,7 @@ use std::borrow::Cow;
 use crate::client::Executor;
 
 #[derive(Clone, Debug, Default, serde::Serialize)]
+#[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
 pub struct Params<'a> {
     /// The country to filter the alternative titles
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -21,6 +22,7 @@ impl<'a> Params<'a> {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
 pub struct MovieAlternativeTitle {
     pub iso_3166_1: String,
     pub title: String,

--- a/src/movie/changes.rs
+++ b/src/movie/changes.rs
@@ -2,12 +2,14 @@ pub use crate::changes::list::Params;
 use crate::client::Executor;
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
 pub struct MovieChange {
     pub key: String,
     pub items: Vec<MovieChangeItem>,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
 pub struct MovieChangeItem {
     pub id: String,
     pub action: String,

--- a/src/movie/images.rs
+++ b/src/movie/images.rs
@@ -4,6 +4,7 @@ use crate::common::image::Image;
 pub type Params<'a> = crate::common::LanguageParams<'a>;
 
 #[derive(Debug, Deserialize, Serialize)]
+#[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
 pub struct GetMovieImagesResponse {
     pub id: u64,
     pub backdrops: Vec<Image>,

--- a/src/movie/lists.rs
+++ b/src/movie/lists.rs
@@ -3,6 +3,7 @@ use crate::common::PaginatedResult;
 pub type Params<'a> = crate::common::LanguagePageParams<'a>;
 
 #[derive(Debug, Deserialize, Serialize)]
+#[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
 pub struct MovieList {
     pub id: u64,
     pub name: String,

--- a/src/movie/mod.rs
+++ b/src/movie/mod.rs
@@ -48,6 +48,7 @@ use crate::company::CompanyShort;
 use crate::genre::Genre;
 
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
 pub struct MovieBase {
     pub id: u64,
     pub title: String,
@@ -66,6 +67,7 @@ pub struct MovieBase {
 }
 
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
 pub struct MovieShort {
     #[serde(flatten)]
     pub inner: MovieBase,
@@ -73,6 +75,7 @@ pub struct MovieShort {
 }
 
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
 pub struct Movie {
     #[serde(flatten)]
     pub inner: MovieBase,

--- a/src/movie/now_playing.rs
+++ b/src/movie/now_playing.rs
@@ -5,6 +5,7 @@ use chrono::NaiveDate;
 use crate::common::PaginatedResult;
 
 #[derive(Clone, Debug, Default, serde::Serialize)]
+#[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
 pub struct Params<'a> {
     /// ISO 639-1 value to display translated data for the fields that support
     /// it.
@@ -48,6 +49,7 @@ impl<'a> Params<'a> {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
 pub struct DateRange {
     #[serde(deserialize_with = "crate::util::empty_string::deserialize")]
     pub maximum: Option<NaiveDate>,
@@ -56,6 +58,7 @@ pub struct DateRange {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
 pub struct ListMoviesNowPlayingResponse {
     #[serde(flatten)]
     pub inner: PaginatedResult<super::MovieShort>,

--- a/src/movie/popular.rs
+++ b/src/movie/popular.rs
@@ -3,6 +3,7 @@ use std::borrow::Cow;
 use crate::common::PaginatedResult;
 
 #[derive(Clone, Debug, Default, serde::Serialize)]
+#[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
 pub struct Params<'a> {
     /// ISO 639-1 value to display translated data for the fields that support
     /// it.

--- a/src/movie/reviews.rs
+++ b/src/movie/reviews.rs
@@ -3,6 +3,7 @@ use crate::common::PaginatedResult;
 pub type Params<'a> = crate::common::LanguagePageParams<'a>;
 
 #[derive(Debug, Deserialize, Serialize)]
+#[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
 pub struct AuthorDetails {
     pub name: String,
     pub username: String,
@@ -11,6 +12,7 @@ pub struct AuthorDetails {
 }
 
 #[derive(Debug, Deserialize, Serialize)]
+#[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
 pub struct MovieReview {
     pub id: String,
     pub author: String,

--- a/src/movie/search.rs
+++ b/src/movie/search.rs
@@ -1,6 +1,7 @@
 use std::borrow::Cow;
 
 #[derive(Clone, Debug, Default, serde::Serialize)]
+#[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
 pub struct Params<'a> {
     /// ISO 639-1 value to display translated data for the fields that support
     /// it.
@@ -78,6 +79,7 @@ impl<'a> Params<'a> {
 }
 
 #[derive(serde::Serialize)]
+#[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
 struct WithQuery<'a, V> {
     query: Cow<'a, str>,
     #[serde(flatten)]

--- a/src/movie/top_rated.rs
+++ b/src/movie/top_rated.rs
@@ -3,6 +3,7 @@ use std::borrow::Cow;
 use crate::common::PaginatedResult;
 
 #[derive(Clone, Debug, Default, serde::Serialize)]
+#[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
 pub struct Params<'a> {
     /// ISO 639-1 value to display translated data for the fields that support
     /// it.

--- a/src/movie/translations.rs
+++ b/src/movie/translations.rs
@@ -1,4 +1,5 @@
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
 pub struct TranslationData {
     #[serde(deserialize_with = "crate::util::empty_string::deserialize")]
     pub title: Option<String>,
@@ -9,6 +10,7 @@ pub struct TranslationData {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
 pub struct Translation {
     pub iso_3166_1: String,
     pub iso_639_1: String,

--- a/src/movie/upcoming.rs
+++ b/src/movie/upcoming.rs
@@ -3,6 +3,7 @@ use std::borrow::Cow;
 use crate::common::PaginatedResult;
 
 #[derive(Clone, Debug, Default, serde::Serialize)]
+#[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
 pub struct Params<'a> {
     /// ISO 639-1 value to display translated data for the fields that support
     /// it.

--- a/src/people/mod.rs
+++ b/src/people/mod.rs
@@ -1,6 +1,7 @@
 pub mod details;
 
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
 pub struct PersonShort {
     pub id: u64,
     pub credit_id: Option<String>,
@@ -10,6 +11,7 @@ pub struct PersonShort {
 }
 
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
 pub struct Person {
     #[serde(flatten)]
     pub inner: PersonShort,

--- a/src/tvshow/images.rs
+++ b/src/tvshow/images.rs
@@ -3,6 +3,7 @@ use std::borrow::Cow;
 use crate::common::image::Image;
 
 #[derive(Clone, Debug, Default, Serialize)]
+#[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
 pub struct Params<'a> {
     /// specify a comma separated list of ISO-639-1 values to query, for
     /// example: en,null
@@ -35,6 +36,7 @@ impl<'a> Params<'a> {
 }
 
 #[derive(Debug, Deserialize, Serialize)]
+#[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
 pub struct GetTVshowImagesResponse {
     pub id: u64,
     pub backdrops: Vec<Image>,

--- a/src/tvshow/mod.rs
+++ b/src/tvshow/mod.rs
@@ -27,6 +27,7 @@ pub mod similar;
 pub mod watch_providers;
 
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
 pub struct TVShowBase {
     pub id: u64,
     pub name: String,
@@ -49,6 +50,7 @@ pub struct TVShowBase {
 }
 
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
 pub struct TVShowShort {
     #[serde(flatten)]
     pub inner: TVShowBase,
@@ -56,6 +58,7 @@ pub struct TVShowShort {
 }
 
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
 pub struct EpisodeShort {
     pub air_date: Option<chrono::NaiveDate>,
     pub episode_number: u64,
@@ -71,6 +74,7 @@ pub struct EpisodeShort {
 }
 
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
 pub struct Episode {
     #[serde(flatten)]
     pub inner: EpisodeShort,
@@ -80,6 +84,7 @@ pub struct Episode {
 }
 
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
 pub struct SeasonBase {
     #[serde(deserialize_with = "crate::util::empty_string::deserialize")]
     pub air_date: Option<chrono::NaiveDate>,
@@ -92,6 +97,7 @@ pub struct SeasonBase {
 }
 
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
 pub struct SeasonShort {
     #[serde(flatten)]
     pub inner: SeasonBase,
@@ -100,6 +106,7 @@ pub struct SeasonShort {
 }
 
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
 pub struct Season {
     pub _id: String,
     #[serde(flatten)]
@@ -108,6 +115,7 @@ pub struct Season {
 }
 
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
 pub struct TVShow {
     #[serde(flatten)]
     pub inner: TVShowBase,

--- a/src/tvshow/search.rs
+++ b/src/tvshow/search.rs
@@ -3,6 +3,7 @@ use std::borrow::Cow;
 const PATH: &str = "/search/tv";
 
 #[derive(Clone, Debug, Default, serde::Serialize)]
+#[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
 pub struct Params<'a> {
     /// ISO 639-1 value to display translated data for the fields that support
     /// it.
@@ -83,6 +84,7 @@ impl<'a> Params<'a> {
 }
 
 #[derive(serde::Serialize)]
+#[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
 struct WithQuery<'a, V> {
     query: Cow<'a, str>,
     #[serde(flatten)]

--- a/src/watch_provider/list.rs
+++ b/src/watch_provider/list.rs
@@ -6,6 +6,7 @@ use crate::client::Executor;
 use crate::common::Results;
 
 #[derive(Debug, Default, serde::Serialize)]
+#[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
 pub struct Params<'a> {
     /// ISO 3166-1 alpha-2 value to filter the results for one country.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -37,6 +38,7 @@ impl<'a> Params<'a> {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
 pub struct WatchProviderDetail {
     /// A hash map of display priority by country code
     pub display_priorities: HashMap<String, u64>,

--- a/src/watch_provider/mod.rs
+++ b/src/watch_provider/mod.rs
@@ -1,6 +1,7 @@
 pub mod list;
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
 pub struct WatchProvider {
     pub provider_id: u64,
     pub provider_name: String,
@@ -9,6 +10,7 @@ pub struct WatchProvider {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[cfg_attr(feature = "ts-rs", derive(ts_rs::TS))]
 pub struct LocatedWatchProvider {
     pub link: String,
     #[serde(default)]


### PR DESCRIPTION
This PR adds ts-rs support with:
- Adds ts-rs as an optional dependency and `ts-rs` feature
- Adds an optional derive to all types that implements `serde::Serialize`